### PR TITLE
Trade Penalty

### DIFF
--- a/lib/nn.cpp
+++ b/lib/nn.cpp
@@ -244,7 +244,12 @@ void Computation::clear()
 float Computation::qVal(int index) const
 {
     Q_ASSERT(index < m_positions);
-    return m_computation->GetQVal(index);
+    auto q = m_computation->GetQVal(index);
+    auto trade_penalty = .003;
+    auto penalty = trade_penalty * (bitboard>piececount - 30);
+    if(depth % 2 == 1)
+      penalty = -penalty;
+    return q + penalty;
 }
 
 void Computation::setPVals(int index, Node *node) const

--- a/lib/nn.cpp
+++ b/lib/nn.cpp
@@ -245,11 +245,16 @@ float Computation::qVal(int index) const
 {
     Q_ASSERT(index < m_positions);
     auto q = m_computation->GetQVal(index);
-    auto trade_penalty = .003;
-    auto penalty = trade_penalty * (bitboard>piececount - 30);
-    if(depth % 2 == 1)
-      penalty = -penalty;
-    return q + penalty;
+    //Apply trade penalty if not very winning or losing.
+    //TODO: Try only if Allie losing
+    if (q < 0.7 && q > 0.3) {
+      auto trade_penalty = .003;
+      auto penalty = trade_penalty * (bitboard>piececount - 30);
+      if(depth % 2 == 1)
+        penalty = -penalty;
+      return q + penalty;
+    }
+    return q;
 }
 
 void Computation::setPVals(int index, Node *node) const


### PR DESCRIPTION
Need depth... I saw a piececount in bitboard.

Having a if winning/losing check would be good. We don't want to apply penalty if we're behind more than 100cp I think. But when you are black against a weak opponent you still want it...
```
if q < 0.7 && q > 0.3
```