### PR TITLE
CUDA directory probing + quick start guide for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,41 @@ I've set up a patreon page here: https://www.patreon.com/gonzochess75 and would 
 
 Yes, I'd like to wholeheartedly thank the developers of the Lc0 project which make Allie even possible. Only by standing on their shoulders could Allie exist. I'd also like to thank Deepmind for their work on AlphaZero which started the whole NN for chess era. Finally, I'd like to thank Andrew Grant who wrote the Ethereal engine whose code was a big inspiration for writing Allie and to CCC and TCEC for including the engine in their tournaments.
 
+# Quick start guide (Linux)
+
+## Prerequisites
+
+You need:
+
+- working build environment: compiler (e.g., GCC or CLANG), binutils, and the rest of the usual stuff.
+- qmake (part of Qt SDK)
+- CUDA and cuDNN. If you can build and run Lc0 with the cuDNN backend, you're probably good.
+
+## Building
+
+The basic steps:
+
+- `qmake` --- Generates the makefiles. Usually only needed to run once.
+- `make -j` --- Build Allie.
+
+If everything went well, you now have `bin/allie` .
+
+If the build system cannot locate CUDA or you want to use a specific CUDA version, you can use NVCC, CUDA_INC_DIR and CUDA_LIB_DIR. For instance:
+
+  `make -j CUDA_INC_DIR=/opt/cuda-10.1.168/include CUDA_LIB_DIR=/opt/cuda-10.1.168/lib64 NVCC=/opt/cuda-10.1.168/bin/nvcc`
+
+Similarly, you can specify the C++ compiler:
+
+  `make -j CXX=clang++-7`
+
+To clean up all the build temporaries:
+
+  `make clean`
+
+There's also `make distclean` to clean up everything, including the targets and the generated makefiles. You need to re-run `qmake` after this command. If in doubt whether changing compiler/CUDA/whatever is in effect, use `make distclean`.
+
+## Running Allie
+
+- Add the network weights file in the same directory with the Allie binary. Symlink (`ln -s`) can be used
+- Launch `allie`. If everything went well, you'll see "allie" in stylished ASCII art with the version information
+- You should now be ready to use Allie with your favorite UCI-compatible chess GUI.


### PR DESCRIPTION
Add support for probing the CUDA directory locations for include and
lib64, and bail out if CUDA was not found. Use /usr/local/cuda and
/opt/cuda as the CUDA bases for probing.

Make nvcc overridable.

Add a quick start guide for building and running on Linux in README.md